### PR TITLE
Fix unet download based on new folder structure

### DIFF
--- a/gradio_dmd.py
+++ b/gradio_dmd.py
@@ -14,7 +14,7 @@ args = parser.parse_args()
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-unet = UNet2DConditionModel.from_pretrained(args.unet_path)
+unet = UNet2DConditionModel.from_pretrained(args.unet_path, subfolder='unet')
 pipe = DiffusionPipeline.from_pretrained(args.model_path, unet=unet)
 pipe.scheduler = DMDScheduler.from_config(pipe.scheduler.config)
 pipe.to(device=device, dtype=torch.float16)


### PR DESCRIPTION
The U-Net is now stored in a subdirectory of the repo [here](https://huggingface.co/Lykon/dreamshaper-8/tree/main/unet). This change ensures that the UNet is downloaded from the right place.

Without this change, the code errors when running `python3 gradio_dmd.py` with the error message:

```
OSError: Lykon/dreamshaper-8 does not appear to have a file named config.json.
```

because there's no config.json in the root directory (anymore)